### PR TITLE
ci: avoid update branch ref collision

### DIFF
--- a/.github/workflows/update-app.yml
+++ b/.github/workflows/update-app.yml
@@ -207,7 +207,7 @@ jobs:
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           base: ${{ github.event.repository.default_branch }}
-          branch: update/ungoogled-chromium
+          branch: update-ungoogled-chromium
           token: ${{ steps.write-app.outputs.token }}
           commit-message: ${{ steps.update.outputs.title }}
           title: ${{ steps.update.outputs.title }}


### PR DESCRIPTION
Use a flat create-pull-request branch name because the repository already has an update branch, which blocks creating refs below update/.